### PR TITLE
Security hardening: SSRF mitigation and cryptographic randomness

### DIFF
--- a/xprez/ck_editor/parse_text.py
+++ b/xprez/ck_editor/parse_text.py
@@ -1,10 +1,74 @@
-import io
+import ipaddress
+import logging
+import socket
 import urllib
+from pathlib import Path
+from urllib.parse import urlparse
 
 from bs4 import BeautifulSoup
+from django.conf import settings as django_settings
 from django.template import Context, Template
 from django.utils.safestring import mark_safe
 from PIL import Image
+
+logger = logging.getLogger(__name__)
+
+MAX_REMOTE_IMAGE_BYTES = 10 * 1024 * 1024  # 10 MB
+REMOTE_FETCH_TIMEOUT = 5  # seconds
+
+
+def _is_private_ip(hostname):
+    """Return True if hostname resolves to a private/loopback/link-local address."""
+    try:
+        for info in socket.getaddrinfo(hostname, None):
+            addr = ipaddress.ip_address(info[4][0])
+            if addr.is_private or addr.is_loopback or addr.is_link_local:
+                return True
+    except socket.gaierror:
+        return True
+    return False
+
+
+def _open_image(src):
+    """Open image from local MEDIA_ROOT or remote URL with SSRF protections."""
+    media_url = django_settings.MEDIA_URL
+    media_root = Path(django_settings.MEDIA_ROOT)
+
+    if src.startswith(media_url):
+        relative_path = src[len(media_url) :]
+        local_path = media_root / relative_path
+        try:
+            resolved = local_path.resolve()
+            if not str(resolved).startswith(str(media_root.resolve())):
+                logger.warning("Image path traversal blocked: %s", src)
+                return None
+            return Image.open(resolved)
+        except (FileNotFoundError, OSError) as exc:
+            logger.warning("Could not open local image %s: %s", src, exc)
+            return None
+
+    parsed = urlparse(src)
+    if parsed.scheme not in ("http", "https"):
+        logger.warning("Unsupported image URL scheme: %s", src)
+        return None
+
+    if _is_private_ip(parsed.hostname):
+        logger.warning("SSRF blocked: %s resolves to private address", src)
+        return None
+
+    req = urllib.request.Request(src, headers={"User-agent": ""})
+    try:
+        resp = urllib.request.urlopen(req, timeout=REMOTE_FETCH_TIMEOUT)
+        data = resp.read(MAX_REMOTE_IMAGE_BYTES + 1)
+        if len(data) > MAX_REMOTE_IMAGE_BYTES:
+            logger.warning("Remote image too large: %s", src)
+            return None
+        import io
+
+        return Image.open(io.BytesIO(data))
+    except Exception:
+        logger.warning("Failed to fetch remote image: %s", src, exc_info=True)
+        return None
 
 
 def _replace_wrapper_with_templatetag(wrapper, img, request):
@@ -18,17 +82,10 @@ def _replace_wrapper_with_templatetag(wrapper, img, request):
     if not src.lower().startswith("http") and request:
         src = request.build_absolute_uri(src)
 
-    request = urllib.request.Request(
-        src,
-        headers={"User-agent": ""},  # needed for cloudflare
-    )
-
-    try:
-        file = io.BytesIO(urllib.request.urlopen(request).read())
-    except Exception as e:
+    im = _open_image(src)
+    if im is None:
         return
 
-    im = Image.open(file)
     width, height = im.size
     classes = list(img.get("class", [])) + list(wrapper.get("class", []))
     if "image-style-align-right" in classes:

--- a/xprez/utils.py
+++ b/xprez/utils.py
@@ -1,5 +1,6 @@
 import copy
-import random
+import secrets
+import string
 
 from .conf import settings
 
@@ -39,11 +40,9 @@ def build_absolute_uri(location, request=None):
     return location
 
 
-def random_string(length, include_special_chars=False):
-    chars = "abcdefghijklmnopqrstuvwxyz0123456789"
-    if include_special_chars:
-        chars += "!@#$%^&*(-_=+)"
-    return "".join([random.choice(chars) for i in range(length)])
+def random_string(length):
+    alphabet = string.ascii_lowercase + string.digits
+    return "".join(secrets.choice(alphabet) for _ in range(length))
 
 
 def truncate_with_ellipsis(string, length):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Two security improvements for the xprez package, targeting `feature/grid`.

### 1. SSRF mitigation in CKEditor image parsing (`ck_editor/parse_text.py`)

The `_replace_wrapper_with_templatetag` function previously called `urllib.request.urlopen()` on arbitrary URLs extracted from `<img src="...">` in stored HTML. This allowed the app server to make outbound HTTP requests to attacker-chosen hosts — including internal IPs, cloud metadata endpoints (169.254.169.254), etc.

**Fix:** New `_open_image()` function that:
- Resolves local `MEDIA_URL` paths directly from `MEDIA_ROOT` on disk (no HTTP round-trip)
- Validates that local paths don't escape `MEDIA_ROOT` (path traversal protection)
- For remote URLs: blocks private/loopback/link-local IPs, enforces a 5-second timeout and 10 MB size limit
- Rejects non-HTTP(S) schemes
- Logs all failures via standard Python logging

### 2. Cryptographically secure random directory names (`utils.py`)

`random_string()` was using `random.choice()` which is not suitable for security-sensitive contexts (upload directory names are used to prevent file overwrites and provide unguessability).

**Fix:** Switched to `secrets.choice()` which uses a cryptographically secure PRNG. Removed the unused `include_special_chars` parameter.

### Not changed (already addressed on `feature/grid`)

- **CSRF**: All `@csrf_exempt` decorators were already removed; admin JS already sends `X-CSRFToken` headers.
- **Upload path sanitization**: Already uses `safe_join()` and `get_valid_filename()`.
- **Object-level auth**: Deferred — low practical risk since all endpoints require staff status. Noted for future improvement.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-018ee5e0-38e0-4267-9b4d-ae9d0b104b4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-018ee5e0-38e0-4267-9b4d-ae9d0b104b4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

