### PR TITLE
Code quality: thorough sweep of xprez package

### DIFF
--- a/example_app/example_app/tests/test_xprez_responsive_sizes.py
+++ b/example_app/example_app/tests/test_xprez_responsive_sizes.py
@@ -89,7 +89,7 @@ class ResponsiveImageHelpersTest(TestCase):
 
 
 class VideoModuleSizesTest(TestCase):
-    """VideoModule get_section_max_width_px and get_image_sizes."""
+    """VideoModule get_section_max_width_px and image_sizes."""
 
     def _video_module(self, section):
         return VideoModule.objects.create(
@@ -125,16 +125,16 @@ class VideoModuleSizesTest(TestCase):
             self.assertEqual(effective_columns, 1)
             self.assertTrue(max_width is None or isinstance(max_width, int))
 
-    def test_get_image_sizes_full_width_contains_100vw(self):
+    def test_image_sizes_full_width_contains_100vw(self):
         section = _create_page_and_section(max_width_choice=constants.MAX_WIDTH_FULL)
         module = self._video_module(section)
-        self.assertEqual(module.get_image_sizes, "100vw")
+        self.assertEqual(module.image_sizes, "100vw")
 
-    def test_get_image_sizes_medium_width_contains_1296px(self):
+    def test_image_sizes_medium_width_contains_1296px(self):
         section = _create_page_and_section(max_width_choice=constants.MAX_WIDTH_MEDIUM)
         module = self._video_module(section)
         self.assertEqual(
-            module.get_image_sizes,
+            module.image_sizes,
             "1296px",
         )
 
@@ -148,7 +148,7 @@ class VideoModuleSizesTest(TestCase):
 
 
 class GalleryModuleSizesTest(TestCase):
-    """GalleryModule get_image_sizes for section+config variants."""
+    """GalleryModule image_sizes for section+config variants."""
 
     def _gallery_module(self, section):
         return GalleryModule.objects.create(section=section, position=0, saved=True)
@@ -156,7 +156,7 @@ class GalleryModuleSizesTest(TestCase):
     def test_section_default_one_column_sizes_contains_vw_or_px(self):
         section = _create_page_and_section()
         module = self._gallery_module(section)
-        sizes = module.get_image_sizes
+        sizes = module.image_sizes
         self.assertIsInstance(sizes, str)
         self.assertTrue("vw" in sizes or "px" in sizes)
 
@@ -167,7 +167,7 @@ class GalleryModuleSizesTest(TestCase):
         config.columns = 1
         config.saved = True
         config.save()
-        self.assertEqual(module.get_image_sizes, "100vw")
+        self.assertEqual(module.image_sizes, "100vw")
 
     def test_gallery_sizes_reflect_section_two_columns_at_breakpoint(
         self,
@@ -185,7 +185,7 @@ class GalleryModuleSizesTest(TestCase):
         config.saved = True
         config.save()
         self.assertEqual(
-            module.get_image_sizes,
+            module.image_sizes,
             "1296px, (max-width: 1499px) 648px",
         )
 
@@ -197,7 +197,7 @@ class GalleryModuleSizesTest(TestCase):
         config.saved = True
         config.save()
         self.assertEqual(
-            gallery.get_image_sizes,
+            gallery.image_sizes,
             "648px",
         )
 
@@ -227,7 +227,7 @@ class GalleryModuleSizesTest(TestCase):
         )
         # Effective: bp0 4*4=16, bp2 2*2=4, bp4 1*1=1 → (None,16), (1199,4), (767,1)
         self.assertEqual(
-            gallery.get_image_sizes,
+            gallery.image_sizes,
             "81px, (max-width: 1199px) 25vw, (max-width: 767px) 100vw",
         )
 
@@ -258,6 +258,6 @@ class GalleryModuleSizesTest(TestCase):
         )
         # Effective: bp0 4*2//2=4, bp2 2*2=4, bp4 1*1=1 → (None,4), (767,1)
         self.assertEqual(
-            gallery.get_image_sizes,
+            gallery.image_sizes,
             "324px, (max-width: 767px) 100vw",
         )

--- a/xprez/admin/admin.py
+++ b/xprez/admin/admin.py
@@ -106,9 +106,9 @@ class XprezAdminMixin(
         return view
 
     def xprez_admin_url_name(self, name, include_namespace=False):
-        name = "{}_{}".format(self.model._meta.model_name, name)
+        name = f"{self.model._meta.model_name}_{name}"
         if include_namespace and self.xprez_url_namespace:
-            name = "{}:{}".format(self.xprez_url_namespace, name)
+            name = f"{self.xprez_url_namespace}:{name}"
         return name
 
     def xprez_admin_urls(self):
@@ -123,11 +123,7 @@ class XprezAdminMixin(
         """Change URL for `obj` in this admin site, or None if not registered."""
         try:
             return reverse(
-                "{namespace}:{app_label}_{model_name}_change".format(
-                    namespace=self.xprez_url_namespace,
-                    app_label=obj._meta.app_label,
-                    model_name=obj._meta.model_name,
-                ),
+                f"{self.xprez_url_namespace}:{obj._meta.app_label}_{obj._meta.model_name}_change",
                 args=[obj.pk],
             )
         except NoReverseMatch:

--- a/xprez/admin/admin.py
+++ b/xprez/admin/admin.py
@@ -1,5 +1,6 @@
 from django.apps import apps
 from django.contrib import admin
+from django.shortcuts import get_object_or_404
 from django.urls import reverse
 from django.urls.exceptions import NoReverseMatch
 
@@ -11,7 +12,7 @@ from xprez.ck_editor.forms import CkEditorFileUploadXprezAdminFormMixin
 from xprez.media import AdminMediaCollector
 
 
-class XprezModelFormMixin(object):
+class XprezModelFormMixin:
     def __init__(self, data=None, files=None, instance=None, **kwargs):
         super().__init__(data=data, files=files, instance=instance, **kwargs)
         self.xprez_sections = []
@@ -134,7 +135,7 @@ class XprezAdminMixin(
 
     def _get_container_instance(self, request, object_pk):
         cls = apps.get_model("xprez", "Container")
-        return cls.objects.get(pk=object_pk)
+        return get_object_or_404(cls, pk=object_pk)
 
 
 class XprezAdmin(XprezAdminMixin, admin.ModelAdmin):
@@ -153,11 +154,7 @@ class XprezAdmin(XprezAdminMixin, admin.ModelAdmin):
 
     def save_model(self, request, obj, form, *args, **kwargs):
         super().save_model(request, obj, form, *args, **kwargs)
-
-        """
-        admin's list_editable bypasses overrided get_form
-        so it does not have save_xprez
-        """
+        # admin's list_editable bypasses overridden get_form, so it may not have xprez_save
         if hasattr(form, "xprez_save"):
             form.xprez_save(request)
 

--- a/xprez/admin/admin.py
+++ b/xprez/admin/admin.py
@@ -21,9 +21,9 @@ class XprezModelFormMixin:
             sections = instance.sections.all()
             section_symlinks = instance.sectionsymlinks.all()
             if data is not None:
-                section_ids = [int(id) for id in data.getlist("section-id")]
+                section_ids = [int(pk) for pk in data.getlist("section-id")]
                 section_symlink_ids = [
-                    int(id) for id in data.getlist("section-symlink-id")
+                    int(pk) for pk in data.getlist("section-symlink-id")
                 ]
                 sections = sections.filter(pk__in=section_ids)
                 section_symlinks = section_symlinks.filter(pk__in=section_symlink_ids)

--- a/xprez/admin/admin.py
+++ b/xprez/admin/admin.py
@@ -21,12 +21,12 @@ class XprezModelFormMixin:
             sections = instance.sections.all()
             section_symlinks = instance.sectionsymlinks.all()
             if data is not None:
-                section_ids = [int(pk) for pk in data.getlist("section-id")]
-                section_symlink_ids = [
+                section_pks = [int(pk) for pk in data.getlist("section-id")]
+                section_symlink_pks = [
                     int(pk) for pk in data.getlist("section-symlink-id")
                 ]
-                sections = sections.filter(pk__in=section_ids)
-                section_symlinks = section_symlinks.filter(pk__in=section_symlink_ids)
+                sections = sections.filter(pk__in=section_pks)
+                section_symlinks = section_symlinks.filter(pk__in=section_symlink_pks)
 
             for section in sections:
                 section.build_admin_form(self.xprez_admin, data, files)

--- a/xprez/admin/views/clipboard.py
+++ b/xprez/admin/views/clipboard.py
@@ -186,7 +186,7 @@ class ClipboardItemContainer(ClipboardItemBase):
         return [self._render(request, self.xprez_admin, item) for item in created]
 
 
-class XprezAdminViewsClipboardMixin(object):
+class XprezAdminViewsClipboardMixin:
     CLIPBOARD_SESSION_KEY = "xprez_clipboard"
     CLIPBOARD_MAX_LENGTH = 10
     CLIPBOARD_ITEM_REGISTRY = {
@@ -195,7 +195,7 @@ class XprezAdminViewsClipboardMixin(object):
     }
 
     def xprez_duplicate_section_view(self, request, section_pk):
-        section = models.Section.objects.get(pk=section_pk)
+        section = get_object_or_404(models.Section, pk=section_pk)
         new_section = section.duplicate_to(section.container)
         new_section.build_admin_form(self)
         return JsonResponse(
@@ -203,7 +203,7 @@ class XprezAdminViewsClipboardMixin(object):
         )
 
     def xprez_duplicate_module_view(self, request, module_pk):
-        module = models.Module.objects.get(pk=module_pk).polymorph
+        module = get_object_or_404(models.Module, pk=module_pk).polymorph
         new_module = module.duplicate_to(module.section)
         new_module.build_admin_form(self)
         return JsonResponse(

--- a/xprez/admin/views/content.py
+++ b/xprez/admin/views/content.py
@@ -1,13 +1,17 @@
-from django.http import JsonResponse
+from django.http import Http404, JsonResponse
+from django.shortcuts import get_object_or_404
 from django.urls import path
 
 from xprez import constants, models, module_registry
 
 
-class XprezAdminViewsContentMixin(object):
+class XprezAdminViewsContentMixin:
     def xprez_add_view(self, request, content_type, container_pk, section_pk=None):
         """Adds a module. Create a section+module if section_pk is not provided."""
-        module_class = module_registry.get(content_type)
+        try:
+            module_class = module_registry.get(content_type)
+        except LookupError:
+            raise Http404
         container = self._get_container_instance(request, container_pk)
         if section_pk is None:
             section = container.sections.create()
@@ -15,14 +19,14 @@ class XprezAdminViewsContentMixin(object):
             section.build_admin_form(self)
             html = section.render_admin({"request": request})
         else:
-            section = container.sections.get(pk=section_pk)
+            section = get_object_or_404(container.sections, pk=section_pk)
             module = module_class.objects.create(section=section)
             module.build_admin_form(self)
             html = module.render_admin({"request": request})
         return JsonResponse([{"html": html}], safe=False)
 
     def xprez_add_section_config_view(self, request, section_pk, css_breakpoint):
-        section = models.Section.objects.get(pk=section_pk)
+        section = get_object_or_404(models.Section, pk=section_pk)
         config, _created = section.get_or_create_config(css_breakpoint)
         config.build_admin_form(self)
         return JsonResponse(
@@ -30,7 +34,7 @@ class XprezAdminViewsContentMixin(object):
         )
 
     def xprez_add_module_config_view(self, request, module_pk, css_breakpoint):
-        module = models.Module.objects.get(pk=module_pk).polymorph
+        module = get_object_or_404(models.Module, pk=module_pk).polymorph
         config, _created = module.get_or_create_config(css_breakpoint)
         config.build_admin_form(self)
         return JsonResponse(

--- a/xprez/ck_editor/parse_text.py
+++ b/xprez/ck_editor/parse_text.py
@@ -98,8 +98,9 @@ def parse_text(text_source, request):
     return str(soup)
 
 
-def render_text_parsed(text_parsed, extra_context={}):
+def render_text_parsed(text_parsed, extra_context=None):
     t = Template("{% load xprez %}" + text_parsed)
     c = Context({})
-    c.update(extra_context)
+    if extra_context:
+        c.update(extra_context)
     return mark_safe(t.render(c))

--- a/xprez/contrib/sorl_thumbnail/thumbnail_backend.py
+++ b/xprez/contrib/sorl_thumbnail/thumbnail_backend.py
@@ -14,17 +14,12 @@ class NamingThumbnailBackendMixin:
         key = tokey(source.key, geometry_string, serialize(options))
 
         # make some subdirs
-        path = "{}/{}/{}".format(key[:2], key[2:4], key)
+        subpath = f"{key[:2]}/{key[2:4]}/{key}"
 
-        # get filename_stem from options or use source name
         filename_stem = slugify(options.get("filename_stem") or Path(source.name).stem)
+        ext = EXTENSIONS[options["format"]]
 
-        return "{}{}/{}.{}".format(
-            settings.THUMBNAIL_PREFIX,
-            path,
-            filename_stem,
-            EXTENSIONS[options["format"]],
-        )
+        return f"{settings.THUMBNAIL_PREFIX}{subpath}/{filename_stem}.{ext}"
 
 
 class NamingThumbnailBackend(NamingThumbnailBackendMixin, ThumbnailBackend):

--- a/xprez/contrib/sorl_thumbnail/thumbnail_backend.py
+++ b/xprez/contrib/sorl_thumbnail/thumbnail_backend.py
@@ -6,7 +6,7 @@ from sorl.thumbnail.conf import settings
 from sorl.thumbnail.helpers import serialize, tokey
 
 
-class NamingThumbnailBackendMixin(object):
+class NamingThumbnailBackendMixin:
     def _get_thumbnail_filename(self, source, geometry_string, options):
         """
         Computes the destination filename.

--- a/xprez/media.py
+++ b/xprez/media.py
@@ -18,9 +18,8 @@ class PrefixableMedia(Media):
         if settings.XPREZ_USE_ABSOLUTE_URI and not path.startswith(
             ("http://", "https://", "//")
         ):
-            return "{}{}".format(settings.XPREZ_BASE_URL, absolute_path)
-        else:
-            return absolute_path
+            return f"{settings.XPREZ_BASE_URL}{absolute_path}"
+        return absolute_path
 
 
 class MediaCollectorBase:

--- a/xprez/models/containers.py
+++ b/xprez/models/containers.py
@@ -11,7 +11,19 @@ from xprez.models.mixins.cache import FrontCacheMixin
 from xprez.utils import class_content_type
 
 
-class Container(FrontCacheMixin, models.Model):
+class PolymorphMixin:
+    """Shared polymorph resolution for models that store content_type as 'app.Model'."""
+
+    @cached_property
+    def polymorph(self):
+        app_label, object_name = self.content_type.split(".")
+        model = apps.get_model(app_label, object_name)
+        if isinstance(self, model):
+            return self
+        return model.objects.get(pk=self.pk)
+
+
+class Container(PolymorphMixin, FrontCacheMixin, models.Model):
     """Base container class for pages/articles that contain modules."""
 
     KEY = constants.CONTAINER_KEY
@@ -31,15 +43,6 @@ class Container(FrontCacheMixin, models.Model):
     @cached_property
     def front_cacheable(self):
         return all(s.front_cacheable for s in self.get_sections_front())
-
-    @cached_property
-    def polymorph(self):
-        app_label, object_name = self.content_type.split(".")
-        model = apps.get_model(app_label, object_name)
-        if isinstance(self, model):
-            return self
-        else:
-            return model.objects.get(pk=self.pk)
 
     def duplicate_to(self, target_container, saved=False, allowed_module_classes=None):
         result = []

--- a/xprez/models/containers.py
+++ b/xprez/models/containers.py
@@ -8,19 +8,8 @@ from django.utils.functional import cached_property
 
 from xprez import constants
 from xprez.models.mixins.cache import FrontCacheMixin
+from xprez.models.mixins.polymorph import PolymorphMixin
 from xprez.utils import class_content_type
-
-
-class PolymorphMixin:
-    """Shared polymorph resolution for models that store content_type as 'app.Model'."""
-
-    @cached_property
-    def polymorph(self):
-        app_label, object_name = self.content_type.split(".")
-        model = apps.get_model(app_label, object_name)
-        if isinstance(self, model):
-            return self
-        return model.objects.get(pk=self.pk)
 
 
 class Container(PolymorphMixin, FrontCacheMixin, models.Model):

--- a/xprez/models/mixins/css.py
+++ b/xprez/models/mixins/css.py
@@ -1,8 +1,6 @@
 from xprez import constants
 from xprez.conf import settings
 
-"TODO: this file need cleanup"
-
 
 def _get_unit_string(css_config, choice=None):
     """Extract unit string from config, handling dict or string units."""

--- a/xprez/models/mixins/polymorph.py
+++ b/xprez/models/mixins/polymorph.py
@@ -1,0 +1,15 @@
+from django.apps import apps
+from django.utils.functional import cached_property
+
+
+class PolymorphMixin:
+    """Shared polymorph resolution for models that store content_type as 'app.Model'."""
+
+    @cached_property
+    def polymorph(self):
+        app_label, object_name = self.content_type.split(".")
+        model = apps.get_model(app_label, object_name)
+        if isinstance(self, model):
+            return self
+        else:
+            return model.objects.get(pk=self.pk)

--- a/xprez/models/mixins/responsive_image.py
+++ b/xprez/models/mixins/responsive_image.py
@@ -39,21 +39,21 @@ class ResponsiveImageParentMixin:
         return max_width, ranges
 
     @cached_property
-    def get_image_sizes(self):
-        """Build HTML sizes attribute string for responsive images."""
+    def image_sizes(self):
+        """HTML sizes attribute string for responsive images."""
         max_width, column_ranges = self.get_column_ranges()
         return self.build_image_sizes(max_width, column_ranges)
 
     @staticmethod
     def parse_crop_string(crop_str):
-        """
-        Parse a crop string like '3/2' into (3, 2), or return None if absent/invalid.
-        """
+        """Parse a crop string like '3/2' into (3, 2), or return None if absent/invalid."""
         if not crop_str or "/" not in crop_str:
             return None
-        else:
+        try:
             num, den = crop_str.split("/", 1)
             return (int(num.strip()), int(den.strip()))
+        except (ValueError, TypeError):
+            return None
 
     @staticmethod
     def build_image_sizes(max_width, column_ranges):
@@ -89,7 +89,7 @@ class ResponsiveImageItemMixin:
         raise NotImplementedError
 
     @cached_property
-    def get_srcset_geometries(self):
+    def srcset_geometries(self):
         """List of 'WxH' geometry strings for srcset, capped at image's natural width."""
         try:
             cap_width = self.get_image_field().width or None
@@ -128,7 +128,7 @@ class ResponsiveImageSourcesMixin:
         raise NotImplementedError
 
     @cached_property
-    def get_media_image_sources(self):
+    def media_image_sources(self):
         """
         Return a list of dicts for <picture> rendering, ordered for correct browser
         matching (smallest max_width first; base/fallback last with max_width=None).

--- a/xprez/models/modules.py
+++ b/xprez/models/modules.py
@@ -1,13 +1,13 @@
 from django.apps import apps
 from django.db import models
 from django.template.loader import render_to_string
-from django.utils.functional import cached_property, classproperty
+from django.utils.functional import classproperty
 
 from xprez import constants
 from xprez.conf import defaults, settings
 from xprez.models.configs import ConfigParentMixin
-from xprez.models.containers import PolymorphMixin
 from xprez.models.mixins.cache import ContentFrontCacheMixin
+from xprez.models.mixins.polymorph import PolymorphMixin
 from xprez.models.querysets.modules import ModuleQuerySet
 from xprez.utils import class_content_type, copy_model, import_class
 
@@ -175,10 +175,10 @@ class Module(PolymorphMixin, ContentFrontCacheMixin, ConfigParentMixin, models.M
 
         self.admin_form.xprez_configs_all_valid = None
         if data:
-            ids = [int(pk) for pk in data.getlist("module-config-id")]
+            pks = [int(pk) for pk in data.getlist("module-config-id")]
             self.admin_form.xprez_configs = list(
                 self.get_config_model()
-                .objects.filter(module=self, pk__in=ids)
+                .objects.filter(module=self, pk__in=pks)
                 .order_by("css_breakpoint")
             )
         else:

--- a/xprez/models/modules.py
+++ b/xprez/models/modules.py
@@ -6,12 +6,13 @@ from django.utils.functional import cached_property, classproperty
 from xprez import constants
 from xprez.conf import defaults, settings
 from xprez.models.configs import ConfigParentMixin
+from xprez.models.containers import PolymorphMixin
 from xprez.models.mixins.cache import ContentFrontCacheMixin
 from xprez.models.querysets.modules import ModuleQuerySet
 from xprez.utils import class_content_type, copy_model, import_class
 
 
-class Module(ContentFrontCacheMixin, ConfigParentMixin, models.Model):
+class Module(PolymorphMixin, ContentFrontCacheMixin, ConfigParentMixin, models.Model):
     """Base module class for content blocks within sections."""
 
     KEY = constants.MODULE_KEY
@@ -109,15 +110,6 @@ class Module(ContentFrontCacheMixin, ConfigParentMixin, models.Model):
     def front_template_name(self):
         return f"xprez/modules/{self.module_key}.html"
 
-    @cached_property
-    def polymorph(self):
-        app_label, object_name = self.content_type.split(".")
-        model = apps.get_model(app_label, object_name)
-        if isinstance(self, model):
-            return self
-        else:
-            return model.objects.get(pk=self.pk)
-
     def duplicate_to(self, target_section, saved=False, **kwargs):
         new_module = copy_model(self)
         new_module.section = target_section
@@ -161,16 +153,15 @@ class Module(ContentFrontCacheMixin, ConfigParentMixin, models.Model):
         )
 
     def get_admin_form_class(self):
-        cls = import_class(self.admin_form_class)
-        if cls._meta.model:
-            return cls
-        else:
+        form_cls = import_class(self.admin_form_class)
+        if form_cls._meta.model:
+            return form_cls
 
-            class ModuleForm(cls):
-                class Meta(cls.Meta):
-                    model = self.__class__
+        class ModuleForm(form_cls):
+            class Meta(form_cls.Meta):
+                model = self.__class__
 
-            return ModuleForm
+        return ModuleForm
 
     def build_admin_form(self, xprez_admin, data=None, files=None):
         form_class = self.get_admin_form_class()
@@ -184,7 +175,7 @@ class Module(ContentFrontCacheMixin, ConfigParentMixin, models.Model):
 
         self.admin_form.xprez_configs_all_valid = None
         if data:
-            ids = [int(id) for id in data.getlist("module-config-id")]
+            ids = [int(pk) for pk in data.getlist("module-config-id")]
             self.admin_form.xprez_configs = list(
                 self.get_config_model()
                 .objects.filter(module=self, pk__in=ids)

--- a/xprez/models/multi_module.py
+++ b/xprez/models/multi_module.py
@@ -1,7 +1,8 @@
 from django.db import models
 from django.http import HttpResponse, JsonResponse
+from django.shortcuts import get_object_or_404
 from django.template.loader import render_to_string
-from django.urls import re_path
+from django.urls import path
 from django.utils.decorators import method_decorator
 
 from xprez.admin.permissions import xprez_staff_member_required
@@ -107,8 +108,8 @@ class MultiModule(Module):
     def get_admin_urls(cls):
         cls_name = cls.__name__.lower()
         return [
-            re_path(
-                r"^{}/add-item/(?P<module_pk>\d+)/".format(cls_name),
+            path(
+                f"{cls_name}/add-item/<int:module_pk>/",
                 cls.add_item_view,
                 name=cls.get_add_item_url_name(),
             ),
@@ -117,7 +118,7 @@ class MultiModule(Module):
     @classmethod
     @method_decorator(xprez_staff_member_required)
     def add_item_view(cls, request, module_pk):
-        module = cls.objects.get(pk=module_pk)
+        module = get_object_or_404(cls, pk=module_pk)
         item = module.create_item()
         form_class = module.get_admin_item_form_class(item)
         item.admin_form = form_class(instance=item, prefix=item.instance_key)
@@ -129,12 +130,12 @@ class MultiModule(Module):
 
     @classmethod
     def get_add_item_url_name(cls):
-        return "{}_ajax_add_item".format(cls.__name__.lower())
+        return f"{cls.__name__.lower()}_ajax_add_item"
 
     @property
     def xprez_add_item_url_name(self):
         ns = getattr(self, "_xprez_admin_namespace", None)
-        return "{}:{}".format(ns, self.get_add_item_url_name()) if ns else ""
+        return f"{ns}:{self.get_add_item_url_name()}" if ns else ""
 
     class Meta:
         abstract = True
@@ -201,7 +202,7 @@ class UploadMultiModule(MultiModule):
     @method_decorator(xprez_staff_member_required)
     def upload_item_view(cls, request, module_pk):
         """Handle one file per request; returns HTML for the new item row."""
-        module = cls.objects.get(pk=module_pk)
+        module = get_object_or_404(cls, pk=module_pk)
         file = request.FILES.get("file")
         if not file:
             return JsonResponse(status=400, data={"error": "No file uploaded"})
@@ -219,8 +220,8 @@ class UploadMultiModule(MultiModule):
     def get_admin_urls(cls):
         cls_name = cls.__name__.lower()
         return super().get_admin_urls() + [
-            re_path(
-                r"^{}/upload-item/(?P<module_pk>\d+)/".format(cls_name),
+            path(
+                f"{cls_name}/upload-item/<int:module_pk>/",
                 cls.upload_item_view,
                 name=cls.get_upload_url_name(),
             ),
@@ -228,9 +229,9 @@ class UploadMultiModule(MultiModule):
 
     @classmethod
     def get_upload_url_name(cls):
-        return "{}_ajax_upload_item".format(cls.__name__.lower())
+        return f"{cls.__name__.lower()}_ajax_upload_item"
 
     @property
     def xprez_upload_item_url_name(self):
         ns = getattr(self, "_xprez_admin_namespace", None)
-        return "{}:{}".format(ns, self.get_upload_url_name()) if ns else ""
+        return f"{ns}:{self.get_upload_url_name()}" if ns else ""

--- a/xprez/models/querysets/modules.py
+++ b/xprez/models/querysets/modules.py
@@ -19,4 +19,8 @@ class ModuleQuerySet(models.QuerySet):
             for polymorph in model_class.objects.filter(pk__in=pks):
                 polymorph_by_pk[polymorph.pk] = polymorph
 
-        return [polymorph_by_pk[module.pk] for module in base_modules]
+        return [
+            polymorph_by_pk[module.pk]
+            for module in base_modules
+            if module.pk in polymorph_by_pk
+        ]

--- a/xprez/models/sections.py
+++ b/xprez/models/sections.py
@@ -1,7 +1,8 @@
 from django.db import models
 from django.template.loader import render_to_string
 from django.utils.functional import cached_property
-from django.utils.translation import gettext_lazy as _, ngettext
+from django.utils.translation import gettext_lazy as _
+from django.utils.translation import ngettext
 
 from xprez import constants
 from xprez.conf import defaults, settings
@@ -149,9 +150,9 @@ class Section(ContentFrontCacheMixin, ConfigParentMixin, SectionBase):
 
         self.admin_form.xprez_configs_all_valid = None
         if data:
-            ids = [int(pk) for pk in data.getlist("section-config-id")]
+            pks = [int(pk) for pk in data.getlist("section-config-id")]
             self.admin_form.xprez_configs = list(
-                self.configs.filter(pk__in=ids).order_by("css_breakpoint")
+                self.configs.filter(pk__in=pks).order_by("css_breakpoint")
             )
         else:
             self.admin_form.xprez_configs = list(self.get_configs())

--- a/xprez/models/sections.py
+++ b/xprez/models/sections.py
@@ -149,7 +149,7 @@ class Section(ContentFrontCacheMixin, ConfigParentMixin, SectionBase):
 
         self.admin_form.xprez_configs_all_valid = None
         if data:
-            ids = [int(id) for id in data.getlist("section-config-id")]
+            ids = [int(pk) for pk in data.getlist("section-config-id")]
             self.admin_form.xprez_configs = list(
                 self.configs.filter(pk__in=ids).order_by("css_breakpoint")
             )

--- a/xprez/modules/code_template.py
+++ b/xprez/modules/code_template.py
@@ -50,7 +50,6 @@ class CodeTemplateModule(FontSizeModuleMixin, Module):
                 logging.getLogger(__name__).warning(
                     "Template not found: %s", self.template_name
                 )
-                return ""
         return ""
 
 

--- a/xprez/modules/code_template.py
+++ b/xprez/modules/code_template.py
@@ -45,9 +45,13 @@ class CodeTemplateModule(FontSizeModuleMixin, Module):
             try:
                 return get_template(self.template_name).render(context=context)
             except TemplateDoesNotExist:
-                return "Invalid Template"
-        else:
-            return ""
+                import logging
+
+                logging.getLogger(__name__).warning(
+                    "Template not found: %s", self.template_name
+                )
+                return ""
+        return ""
 
 
 class CodeTemplateModuleForm(ModuleForm):

--- a/xprez/modules/numbers.py
+++ b/xprez/modules/numbers.py
@@ -21,7 +21,7 @@ class NumbersModule(FontSizeModuleMixin, MultiModule):
     admin_icon_template_name = "xprez/shared/icons/modules/numbers.html"
 
     class Meta:
-        verbose_name = "Numbers"
+        verbose_name = _("Numbers")
 
     class FrontMedia:
         js = ("xprez/js/numbers.min.js",)

--- a/xprez/modules/quote.py
+++ b/xprez/modules/quote.py
@@ -1,4 +1,3 @@
-from django import forms
 from django.db import models
 from django.utils.html import strip_tags
 from django.utils.translation import gettext_lazy as _

--- a/xprez/modules/symlink.py
+++ b/xprez/modules/symlink.py
@@ -40,3 +40,4 @@ class ModuleSymlink(Module):
     def preview_text(self):
         if self.symlink:
             return self.symlink.polymorph.preview_text()
+        return None

--- a/xprez/modules/text.py
+++ b/xprez/modules/text.py
@@ -86,7 +86,7 @@ class TextModule(ResponsiveImageSourcesMixin, ResponsiveImageMixin, TextModuleBa
         return config.media_crop if config else None
 
     def get_image_aspect_ratio(self):
-        """Base-config crop ratio for get_srcset_geometries; falls back to (1, 1)."""
+        """Base-config crop ratio for srcset_geometries; falls back to (1, 1)."""
         config = self.configs.filter(css_breakpoint=0).first()
         crop = self.parse_crop_string(self.get_config_crop(config))
         if crop:

--- a/xprez/registry.py
+++ b/xprez/registry.py
@@ -8,7 +8,13 @@ class ModuleRegistry:
         self._registry = OrderedDict()
 
     def get(self, content_type):
-        return self._registry[content_type]
+        try:
+            return self._registry[content_type]
+        except KeyError:
+            raise LookupError(
+                f"Module type '{content_type}' is not registered. "
+                f"Available: {', '.join(self._registry.keys())}"
+            )
 
     def register(self, module_class):
         keys = {m.module_key for m in self._registry.values()}

--- a/xprez/registry.py
+++ b/xprez/registry.py
@@ -14,7 +14,7 @@ class ModuleRegistry:
             raise LookupError(
                 f"Module type '{content_type}' is not registered. "
                 f"Available: {', '.join(self._registry.keys())}"
-            )
+            ) from None
 
     def register(self, module_class):
         keys = {m.module_key for m in self._registry.values()}

--- a/xprez/templates/xprez/modules/gallery.html
+++ b/xprez/templates/xprez/modules/gallery.html
@@ -6,7 +6,7 @@
 
 {% block content %}
     {% for item in items %}
-        {% with alt=item.alt_text|default:item.description geoms=item.get_srcset_geometries %}
+        {% with alt=item.alt_text|default:item.description geoms=item.srcset_geometries %}
         <figure class="xprez-gallery__item-cont js-photo"
             {% thumbnail item.file "2000x2000" upscale=false format="WEBP" quality=90 filename_stem=alt as thumb %}
             data-original_url="{{ thumb.url|build_absolute_uri }}"
@@ -21,7 +21,7 @@
                 src="{{ t_src.url|build_absolute_uri }}"
                 {% endthumbnail %}
                 srcset="{% for geom in geoms %}{% thumbnail item.file geom crop=module.thumbnail_crop format="WEBP" quality=70 filename_stem=alt as t %}{{ t.url|build_absolute_uri }} {{ t.width }}w{% if not forloop.last %}, {% endif %}{% endthumbnail %}{% endfor %}"
-                sizes="{{ module.get_image_sizes }}" />
+                sizes="{{ module.image_sizes }}" />
             {% if item.description %}
                 <figcaption class="xprez-gallery__item-caption">{{ item.description }}</figcaption>
             {% endif %}

--- a/xprez/templates/xprez/modules/text.html
+++ b/xprez/templates/xprez/modules/text.html
@@ -14,19 +14,19 @@
         <div class="xprez-text__image-wrapper">
             {% if module.media_is_image %}
                 <picture>
-                    {% for source in module.get_media_image_sources %}
+                    {% for source in module.media_image_sources %}
                         {% if source.max_width %}
                             <source
                                 media="(max-width: {{ source.max_width }}px)"
                                 srcset="{% for geom in source.geometries %}{% thumbnail module.media geom crop=source.thumbnail_crop format="WEBP" quality=70 as t %}{{ t.url|build_absolute_uri }} {{ t.width }}w{% if not forloop.last %}, {% endif %}{% endthumbnail %}{% endfor %}"
-                                sizes="{{ module.get_image_sizes }}">
+                                sizes="{{ module.image_sizes }}">
                         {% else %}
                             {% thumbnail module.media source.geometries.0 crop=source.thumbnail_crop format="WEBP" quality=70 as t_src %}
                             <img class="xprez-text__image"
                                 src="{{ t_src.url|build_absolute_uri }}"
                                 {% endthumbnail %}
                                 srcset="{% for geom in source.geometries %}{% thumbnail module.media geom crop=source.thumbnail_crop format="WEBP" quality=70 as t %}{{ t.url|build_absolute_uri }} {{ t.width }}w{% if not forloop.last %}, {% endif %}{% endthumbnail %}{% endfor %}"
-                                sizes="{{ module.get_image_sizes }}"
+                                sizes="{{ module.image_sizes }}"
                                 alt="{{ module.media.name }}"
                                 loading="lazy">
                         {% endif %}

--- a/xprez/templates/xprez/modules/video.html
+++ b/xprez/templates/xprez/modules/video.html
@@ -6,14 +6,14 @@
 {% block content %}
     <div class="xprez-video__item"{% if module.poster_image %} data-video-with-poster{% endif %}>
         {% if module.poster_image %}
-            {% with geoms=module.get_srcset_geometries %}
+            {% with geoms=module.srcset_geometries %}
                 <div class="xprez-video__poster xprez-video-poster-{{ module.video_id }}" data-video-poster>
                     {% thumbnail module.poster_image geoms.0 crop="50%" format="WEBP" quality=70 as t_src %}
                     <img class="xprez-video__poster-img"
                          src="{{ t_src.url|build_absolute_uri }}"
                          {% endthumbnail %}
                          srcset="{% for geom in geoms %}{% thumbnail module.poster_image geom crop="50%" format="WEBP" quality=70 as t %}{{ t.url|build_absolute_uri }} {{ t.width }}w{% if not forloop.last %}, {% endif %}{% endthumbnail %}{% endfor %}"
-                         sizes="{{ module.get_image_sizes }}"
+                         sizes="{{ module.image_sizes }}"
                          alt="{{ module.video_type }} video poster" />
                     <div class="xprez-video__btn-cont">
                         {% include "xprez/shared/icons/video_play.html" %}

--- a/xprez/templatetags/xprez.py
+++ b/xprez/templatetags/xprez.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-
-from __future__ import unicode_literals
-
 from django import template
 
 from ..media import FrontendMediaCollector
@@ -92,7 +88,7 @@ def _editor_module_image(
         "width": width,
         "height": height,
         "lightbox": lightbox,
-        "max_size": "%sx%s" % (max_size["width"], max_size["height"]),
+        "max_size": f"{max_size['width']}x{max_size['height']}",
         "link_url": link_url,
         "link_new_window": link_new_window,
         "caption": caption,

--- a/xprez/templatetags/xprez_admin.py
+++ b/xprez/templatetags/xprez_admin.py
@@ -51,9 +51,9 @@ def xprez_file_thumbnail(value, size="400x200"):
         return None
     try:
         with value.open("rb") as f:
-            Image.open(f)  # check if file is an image
+            Image.open(f)
         return get_thumbnail(value, size, format="WEBP", quality=80) or None
-    except Exception:
+    except (OSError, ValueError):
         return None
 
 

--- a/xprez/utils.py
+++ b/xprez/utils.py
@@ -14,28 +14,27 @@ def copy_model(instance):
 
 
 def import_class(cls):
+    """Import a class from a dotted path string, or return cls if already a class."""
     if isinstance(cls, str):
-        d = cls.rfind(".")
-        classname = cls[d + 1 : len(cls)]
-        m = __import__(cls[0:d], globals(), locals(), [classname])
+        dot = cls.rfind(".")
+        if dot == -1:
+            raise ImportError(f"import_class requires a dotted path, got: {cls!r}")
+        module_path, classname = cls[:dot], cls[dot + 1 :]
+        m = __import__(module_path, globals(), locals(), [classname])
         return getattr(m, classname)
-    else:
-        return cls
+    return cls
 
 
 def class_content_type(cls):
-    return "{}.{}".format(
-        cls._meta.app_label,
-        cls._meta.object_name,
-    )
+    return f"{cls._meta.app_label}.{cls._meta.object_name}"
 
 
 def build_absolute_uri(location, request=None):
     if settings.XPREZ_USE_ABSOLUTE_URI:
-        if location.lower().startswith(("http://", "https://", "//")):
+        if not location.lower().startswith(("http://", "https://", "//")):
             if request:
                 return request.build_absolute_uri(location)
-            return "{}{}".format(settings.XPREZ_BASE_URL, location)
+            return f"{settings.XPREZ_BASE_URL}{location}"
     return location
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

A thorough code-quality and elegance sweep across the entire `xprez/` package. No backwards compatibility constraints — this targets `feature/grid`.

**All 76 tests pass.**

---

### Commits

#### 1. Fix mutable default argument in `render_text_parsed`
- `ck_editor/parse_text.py`: Replace `extra_context={}` with `extra_context=None` to avoid the classic mutable default argument bug.

#### 2. Remove dead code: obsolete Python 2 compat, unused imports, stray string
- `templatetags/xprez.py`: Remove `# -*- coding: utf-8 -*-` and `from __future__ import unicode_literals`; use f-string instead of `%`-formatting.
- `models/mixins/css.py`: Remove stray string expression `"TODO: this file need cleanup"` (was a no-op expression, not a docstring).
- `modules/quote.py`: Remove unused `from django import forms`.

#### 3. Improve error handling and remove Python 2 `object` base class
- `registry.py`: `get()` now raises `LookupError` with helpful message listing available types, instead of raw `KeyError`.
- `admin/views/content.py`: Use `get_object_or_404` for DB lookups, catch `LookupError` for unknown content types.
- `admin/views/clipboard.py`: Use `get_object_or_404` for duplicate views.
- `admin/admin.py`: Use `get_object_or_404` in `_get_container_instance`, fix misplaced triple-quoted string.
- `templatetags/xprez_admin.py`: Narrow bare `except Exception` to `(OSError, ValueError)`.
- `contrib/sorl_thumbnail`: Drop unnecessary `(object)` base.

#### 4. Modernize code: f-strings, `path()` over `re_path()`, `import_class` robustness
- `models/multi_module.py`: Replace `re_path` with `path()` for URL patterns, use `get_object_or_404` for AJAX views.
- `utils.py`: Add validation to `import_class` for non-dotted paths, fix `build_absolute_uri` condition (was inverted — applied absolute prefix to URLs that already had scheme).
- f-string conversions throughout `admin/admin.py`, `contrib/sorl_thumbnail`, `media.py`.

#### 5. DRY: extract `PolymorphMixin`, fix naming and missing returns
- `models/containers.py`: Extract `PolymorphMixin` for shared polymorph resolution (was duplicated identically in `Container` and `Module`).
- `models/modules.py`: Use `PolymorphMixin`, remove duplicate `polymorph` property, fix `cls` variable shadowing in `get_admin_form_class`, rename `id` to `pk` in comprehensions to avoid shadowing builtin.
- `admin/admin.py`, `models/sections.py`: Same `id` -> `pk` rename.
- `modules/symlink.py`: Add explicit `return None` for missing-symlink branch.

#### 6. Deep sweep: naming, defensive handling, i18n consistency
- `models/mixins/responsive_image.py`: Rename `@cached_property` from verb form (`get_image_sizes`, `get_srcset_geometries`, `get_media_image_sources`) to noun form (`image_sizes`, `srcset_geometries`, `media_image_sources`); add `ValueError` handling in `parse_crop_string`.
- `models/querysets/modules.py`: Skip missing polymorphic rows instead of raising `KeyError`.
- `modules/code_template.py`: Log missing template via `logging.warning` instead of returning `"Invalid Template"` string to user.
- `modules/numbers.py`: Wrap `verbose_name` in `_()` for i18n consistency.
- Templates and tests updated for all renamed properties.

---

### Test results
All 76 tests pass on both the security branch and this code quality branch.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-018ee5e0-38e0-4267-9b4d-ae9d0b104b4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-018ee5e0-38e0-4267-9b4d-ae9d0b104b4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

