### PR TITLE
Update GitHub Actions to Node.js 24-compatible versions.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,12 +15,12 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         ref: ${{ github.ref_name }}
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.x'
 
@@ -63,7 +63,7 @@ jobs:
         pip install setuptools wheel twine
 
     - name: Create GitHub Release
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@v3
       with:
         tag_name: v${{ github.event.inputs.version }}
         name: v${{ github.event.inputs.version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,12 +21,12 @@ jobs:
                 options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
         steps:
-            -   uses: actions/checkout@v3
-            -   uses: actions/setup-python@v4
+            -   uses: actions/checkout@v5
+            -   uses: actions/setup-python@v6
                 with:
                     python-version: '3.10'
                     cache: 'pip' # caching pip dependencies
-            -   uses: pre-commit/action@v3.0.0
+            -   uses: pre-commit/action@v3.0.1
                 with:
                     extra_args: --all-files
 


### PR DESCRIPTION
Bump checkout, setup-python, and release/pre-commit actions before the Node 20 runner deprecation.